### PR TITLE
Fix location of nobootsound_logoutvol

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
 # Install the script by moving the two script files 
-# to the user home directory ~ (hiding them with a dot .)
-# and then hooking them to the login and logout
+# to the /Library/LogHook/ directory and then 
+# hooking them to the login and logout.
 #
 
 installation_folder="/Library/LogHook/"

--- a/nobootsound_loginhook
+++ b/nobootsound_loginhook
@@ -2,6 +2,8 @@
 # Read the value stored in .noboot_logoutvol to determine wether the
 # computer was muted before shutdown
 
-read val < .nobootsound_logoutvol
+logoutvolume="/Library/LogHook/nobootsound_logoutvol"
+
+read val < "$logoutvolume"
 logger "Nobootsound restoring volume to previous value. Mute: $val"
 osascript -e "if not $val then set volume without output muted"

--- a/nobootsound_logouthook
+++ b/nobootsound_logouthook
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+logoutvolume="/Library/LogHook/nobootsound_logoutvol"
+
 # Store the state of volume right before shutdown
-osascript -e 'output muted of (get volume settings)' > .nobootsound_logoutvol
-read val < .nobootsound_logoutvol
+osascript -e 'output muted of (get volume settings)' > "$logoutvolume"
+read val < "$logoutvolume"
 logger "Nobootsound. Volume muted before shutdown: $val"
 # Mute volume, so that no sound will be played at boot
 osascript -e 'set volume with output muted'


### PR DESCRIPTION
In the Pull request #5, I changed the folder of nobootsound_logoutvol to /Library/LogHook in install.sh, but I forgot to do the same in nobootsound_loginhook and nobootsound_logouthook. This Pull request fixes this.
